### PR TITLE
event swipe must not send action with the same name as the variable swipe

### DIFF
--- a/addon/components/slick-slider.js
+++ b/addon/components/slick-slider.js
@@ -107,7 +107,7 @@ export default Ember.Component.extend({
       _this.sendAction('setPosition', slick);
     })
     .on('swipe', function (slick, direction) {
-      _this.sendAction('swipe', slick, direction);
+      _this.sendAction('swiped', slick, direction);
     });
   })
 });


### PR DESCRIPTION
sendAction confuses and think that an event "true" (the default value for swipe var) is being called.
