### PR TITLE
fix jQuery event wrapping and allow ember cli to create sourcemap

### DIFF
--- a/addon/components/slick-slider.js
+++ b/addon/components/slick-slider.js
@@ -91,22 +91,22 @@ export default Ember.Component.extend({
       verticalSwiping  : this.get('verticalSwiping'),
       rtl              : this.get('rtl')
     })
-    .on('afterChange', function (slick, currentSlide) {
+    .on('afterChange', function ($event, slick, currentSlide) {
       _this.sendAction('afterChange', slick, currentSlide);
     })
-    .on('beforeChange', function (slick, currentSlide, nextSlide) {
+    .on('beforeChange', function ($event, slick, currentSlide, nextSlide) {
       _this.sendAction('beforeChange', slick, currentSlide, nextSlide);
     })
-    .on('edge', function (slick, direction) {
+    .on('edge', function ($event, slick, direction) {
       _this.sendAction('edge', slick, direction);
     })
-    .on('reInit', function (slick) {
+    .on('reInit', function ($event, slick) {
       _this.sendAction('reInit', slick);
     })
-    .on('setPosition', function (slick) {
+    .on('setPosition', function ($event, slick) {
       _this.sendAction('setPosition', slick);
     })
-    .on('swipe', function (slick, direction) {
+    .on('swipe', function ($event, slick, direction) {
       _this.sendAction('swiped', slick, direction);
     });
   })

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
     this.app.import(app.bowerDirectory + '/slick-carousel/slick/slick.css');
-    this.app.import(app.bowerDirectory + '/slick-carousel/slick/slick.min.js');
+    this.app.import(app.bowerDirectory + '/slick-carousel/slick/slick.js');
     this.app.import(app.bowerDirectory + '/slick-carousel/slick/slick-theme.css');
     this.app.import(app.bowerDirectory + '/slick-carousel/slick/fonts/slick.ttf', { destDir: 'assets/fonts' });
     this.app.import(app.bowerDirectory + '/slick-carousel/slick/fonts/slick.svg', { destDir: 'assets/fonts' });

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "target": "ES6",
+        "module": "commonjs"
+    },
+    "exclude": [
+        "node_modules",
+        "bower_components"
+    ]
+}


### PR DESCRIPTION
As http://api.jquery.com/on/, the handler first argument is jquery event. currently it swallow the last param at latest jquery version.

Also, should import slick.js, and let ember cli to manage the next process.
