### PR TITLE
unslick the slick slider on component destroy to avoid memory leaks

### DIFF
--- a/addon/components/slick-slider.js
+++ b/addon/components/slick-slider.js
@@ -1,8 +1,9 @@
 import { scheduleOnce } from '@ember/runloop';
 import Component from '@ember/component';
 import layout from '../templates/components/slick-slider';
+import { InvokeActionMixin } from 'ember-invoke-action';
 
-export default Component.extend({
+export default Component.extend(InvokeActionMixin, {
   layout: layout,
   accessibility: true,
   adaptiveHeight: true,
@@ -61,7 +62,7 @@ export default Component.extend({
     var _this = this;
 
     scheduleOnce('actions', this.$(), function() {
-      _this.sendAction('slickInit', this[0]);
+      _this.invokeAction('slickInit', this[0]);
     });
 
     return this.$().slick({
@@ -110,24 +111,24 @@ export default Component.extend({
       rtl              : this.get('rtl')
     })
     .on('afterChange', function ($event, slick, currentSlide) {
-      _this.sendAction('afterChange', slick, currentSlide);
+      _this.invokeAction('afterChange', slick, currentSlide);
     })
     .on('beforeChange', function ($event, slick, currentSlide, nextSlide) {
-      _this.sendAction('beforeChange', slick, currentSlide, nextSlide);
+      _this.invokeAction('beforeChange', slick, currentSlide, nextSlide);
     })
     .on('edge', function ($event, slick, direction) {
-      _this.sendAction('edge', slick, direction);
+      _this.invokeAction('edge', slick, direction);
     })
     .on('reInit', function ($event, slick) {
-      _this.sendAction('reInit', slick);
+      _this.invokeAction('reInit', slick);
     })
     .on('setPosition', function ($event, slick) {
       if(!_this.get('isDestroyed')) {
-        _this.sendAction('setPosition', slick);
+        _this.invokeAction('setPosition', slick);
       }
     })
     .on('swipe', function ($event, slick, direction) {
-      _this.sendAction('swiped', slick, direction);
+      _this.invokeAction('swiped', slick, direction);
     });
   },
   willDestroyElement(){

--- a/addon/components/slick-slider.js
+++ b/addon/components/slick-slider.js
@@ -129,5 +129,9 @@ export default Component.extend({
     .on('swipe', function ($event, slick, direction) {
       _this.sendAction('swiped', slick, direction);
     });
+  },
+  willDestroyElement(){
+    this._super(...arguments);
+    this.$().slick('unslick');
   }
 });

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-cli-uglify": "^2.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
+    "ember-invoke-action": "^1.5.1",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^5.0.1",


### PR DESCRIPTION
When profiling my test suite that runs super slowly after a few minutes, I saw that no instance of slick slider was destroyed. Retaining `_this` via the listener's was causing my 2.18 ember app to retain the router micro lib and all of it's states between each test...an unbounded memory leak. 

This should fix:

- [33](https://github.com/laantorchaweb/ember-cli-slick/issues/33)
- [5](https://github.com/laantorchaweb/ember-cli-slick/issues/25)
